### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ New version tag for release to PyPI (previous "Archimedes" project tagged with v
 - Overhaul `spatial` module: `Attitude` protocol, low-level functions, wrapper classes, `RigidBody` singleton ([Issue #114](https://github.com/PineTreeLabs/archimedes/issues/114))
 - Bugfix for struct type name resolution with inner classes ([Issue #115](https://github.com/PineTreeLabs/archimedes/issues/115))
 
-## [0.4.1] - WIP
+## [0.4.1] - 2025-11-26
 - Performance improvements to `@compile` calls from Python runtime
 - Add `buffered` mode to `@compile`
 - Support addition and scalar multiplication for `Quaternion`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archimedes"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python framework for modeling, simulation, and controls development"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "archimedes"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "casadi" },


### PR DESCRIPTION
Releasing patch version mainly to include #122 and #123 bugfixes

Full changelog:
- Performance improvements to `@compile` calls from Python runtime
- Add `buffered` mode to `@compile`
- Support addition and scalar multiplication for `Quaternion`
- Bugfix for non-commutative broadcasting (PR [#122](https://github.com/PineTreeLabs/archimedes/pull/122) and [#123](https://github.com/PineTreeLabs/archimedes/pull/123))