### PR TITLE
Fix HashablePartial hash/eq failure with numpy array static fields

### DIFF
--- a/src/archimedes/tree/_flatten_util.py
+++ b/src/archimedes/tree/_flatten_util.py
@@ -47,6 +47,15 @@ if TYPE_CHECKING:
 _SIGNATURE_CACHE = {}
 
 
+def _make_hashable(x):
+    """Recursively convert unhashable types (e.g. numpy arrays) to hashable form."""
+    if isinstance(x, np.ndarray):
+        return (x.shape, x.dtype, x.tobytes())
+    if isinstance(x, (tuple, list)):  # covers NamedTuples (e.g. TreeDef) too
+        return tuple(_make_hashable(i) for i in x)
+    return x
+
+
 # Original: jax._src.util.HashablePartial
 class HashablePartial:
     def __init__(self, f, *args, **kwargs):
@@ -82,16 +91,18 @@ class HashablePartial:
         return (
             type(other) is HashablePartial
             and self.f.__code__ == other.f.__code__
-            and self.args == other.args
-            and self.kwargs == other.kwargs
+            and _make_hashable(self.args) == _make_hashable(other.args)
+            and _make_hashable(self.kwargs) == _make_hashable(other.kwargs)
         )
 
     def __hash__(self):
         return hash(
             (
                 self.f.__code__,
-                self.args,
-                tuple(sorted(self.kwargs.items(), key=lambda kv: kv[0])),
+                _make_hashable(self.args),
+                _make_hashable(
+                    tuple(sorted(self.kwargs.items(), key=lambda kv: kv[0]))
+                ),
             ),
         )
 

--- a/test/tree/test_tree.py
+++ b/test/tree/test_tree.py
@@ -433,6 +433,68 @@ class TestRavel:
         assert f(x, {"a": 1}) == x[0]
         assert f(x, {"b": 1}) == x[1]
 
+    def test_ravel_hashable_with_array_static_field(self):
+        # Regression test: ravel_tree returns a HashablePartial wrapping the
+        # TreeDef. When a struct has numpy arrays as static fields, those arrays
+        # end up in TreeDef.node_data. HashablePartial.__hash__ must handle them
+        # without raising "TypeError: unhashable type: 'numpy.ndarray'".
+
+        @struct
+        class LookupTable:
+            breakpoints: np.ndarray = field(static=True)
+            values: np.ndarray
+
+        t = LookupTable(
+            breakpoints=np.array([0.0, 1.0, 2.0]),
+            values=np.array([10.0, 20.0, 30.0]),
+        )
+
+        _, unravel = tree.ravel(t)
+        # Should not raise TypeError
+        h = hash(unravel)
+        assert isinstance(h, int)
+
+        # Two structs with identical static fields should produce equal unravel
+        # functions (same hash, same equality) so the compile cache hits.
+        t2 = LookupTable(
+            breakpoints=np.array([0.0, 1.0, 2.0]),
+            values=np.array([100.0, 200.0, 300.0]),
+        )
+        _, unravel2 = tree.ravel(t2)
+        assert hash(unravel) == hash(unravel2)
+        assert unravel == unravel2
+
+        # Structs with different static fields (different breakpoints) should
+        # produce different unravel functions so recompilation is triggered.
+        t3 = LookupTable(
+            breakpoints=np.array([0.0, 5.0, 10.0]),
+            values=np.array([10.0, 20.0, 30.0]),
+        )
+        _, unravel3 = tree.ravel(t3)
+        assert hash(unravel) != hash(unravel3)
+        assert unravel != unravel3
+
+    def test_ravel_compile_with_array_static_field(self):
+        # Integration test: a compiled function receiving a struct with numpy
+        # array static fields should not raise on the cache key hash check.
+
+        @struct
+        class LookupTable:
+            breakpoints: np.ndarray = field(static=True)
+            values: np.ndarray
+
+        @compile
+        def f(t):
+            return np.sum(t.values)
+
+        t = LookupTable(
+            breakpoints=np.array([0.0, 1.0, 2.0]),
+            values=np.array([10.0, 20.0, 30.0]),
+        )
+
+        result = f(t)
+        assert float(result) == 60.0
+
 
 def test_register_struct():
     # Mark static fields using `field`


### PR DESCRIPTION
## Summary

- `HashablePartial.__hash__` and `__eq__` raised errors when a `@struct` had a `numpy.ndarray` static field (e.g. `field(static=True)`)
- The array ends up in `TreeDef.node_data` after `tree_flatten`, which gets captured as an arg in the `HashablePartial` returned by `ravel_tree`
- The compile cache check (`if key not in self._cache`) then calls `__hash__`, hitting `TypeError: unhashable type: 'numpy.ndarray'`; the same path through `__eq__` would raise `ValueError: ambiguous truth value`

Fixes by adding `_make_hashable()` that recursively converts numpy arrays to `(shape, dtype, tobytes())` and NamedTuples/lists to plain tuples, applied to both `__hash__` and `__eq__`.

## Test plan

- `TestRavel::test_ravel_hashable_with_array_static_field` — unit test: `HashablePartial` from `ravel_tree` is hashable; same breakpoints → equal unravel functions; different breakpoints → different unravel functions
- `TestRavel::test_ravel_compile_with_array_static_field` — integration test: `@compile`d function called with a struct having an array static field runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)